### PR TITLE
Update ProcessWindowsLoginAsync to login with correct cookie

### DIFF
--- a/Quickstart/Account/ExternalController.cs
+++ b/Quickstart/Account/ExternalController.cs
@@ -194,7 +194,7 @@ namespace IdentityServer4.Quickstart.UI
                 }
 
                 await HttpContext.SignInAsync(
-                    IdentityServer4.IdentityServerConstants.ExternalCookieAuthenticationScheme,
+                    IdentityConstants.ExternalScheme,
                     new ClaimsPrincipal(id),
                     props);
                 return Redirect(props.RedirectUri);


### PR DESCRIPTION
I had to make this change otherwise `ExternalController.Callback()`  would throw on:

```cs
            var result = await HttpContext.AuthenticateAsync(IdentityConstants.ExternalScheme);
            if (result?.Succeeded != true)
            {
                throw new Exception("External authentication error");
            }
```

Because `result` would be `null`.